### PR TITLE
Add FontsWiki to font resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Please adhere to this project's [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md).
 - [DevFonts](https://devfonts.gafi.dev/)
 - [FontFabric](https://www.fontfabric.com/)
 - [Fontjoy](https://fontjoy.com/)
+- [FontsWiki](https://fontswiki.com/)
 - [Fontsly](https://www.fontsly.com/)
 - [FontSpace](https://www.fontspace.com/)
 - [FontZone](https://www.fontzone.net/)


### PR DESCRIPTION
Adds FontsWiki (https://fontswiki.com/) to this repo's relevant font, typography, or design resources section.