### PR TITLE
Add CSS Grid Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Please adhere to this project's [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md).
 - [Blob Maker](https://www.blobmaker.app/)
 - [Claymorphism Generator](https://cssnippets.shefali.dev/claymorphismgenerator)
 - [Clip Path Generator](https://bennettfeely.com/clippy/)
+- [CSS Grid Generator](https://alltoolsverse.com/tools/css-grid-generator/)
 - [Glassmorphism Generator](https://markodenic.com/tools/glassmorphism-css-generator/)
 - [Gradient Background Generator](https://cssnippets.shefali.dev/gradientbackgroundgenerator)
 - [Neumorphism Generator](https://neumorphism.io/)


### PR DESCRIPTION
## Summary

Adds [CSS Grid Generator](https://alltoolsverse.com/tools/css-grid-generator/) to the CSS Generators section.

## Why it fits

- Free and directly relevant to web development.
- Builds CSS Grid layouts with a live preview and copyable CSS and HTML output.
- Added in the existing list format and in alphabetical position.

## Verification

Tested a 4-column, 2-row grid with a 16px column gap and a 12px row gap. The tool generated the expected values:

```css
grid-template-columns: repeat(4, 1fr);
grid-template-rows: repeat(2, 1fr);
gap: 12px 16px;
```

Disclosure: I help build All Tools Verse. This PR was prepared with assistance from OpenAI Codex and manually reviewed.