### PR TITLE
Add FrontendAtlas Machine Coding to learning resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Please adhere to this project's [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md).
 - [Coursera](https://www.coursera.org/)
 - [freeCodeCamp](https://www.freecodecamp.org/)
 - [Frontend Mentor](https://www.frontendmentor.io/)
+- [FrontendAtlas Machine Coding](https://frontendatlas.com/machine-coding)
 - [Javascript30](https://javascript30.com/)
 - [Khan Academy](https://www.khanacademy.org/)
 - [Learnify](https://learnify.shefali.dev/)


### PR DESCRIPTION
Adds FrontendAtlas Machine Coding under Learn Web Development → Websites, in alphabetical order.

The hub provides frontend machine-coding and UI practice across components, JavaScript utilities, React, Angular, and Vue.

Disclosure: I’m the creator and maintainer of FrontendAtlas and am submitting my own resource. The hub is publicly browsable and selected challenges are free to start; deeper sets or solutions may require Premium, so FrontendAtlas should be treated as freemium.